### PR TITLE
Add Lazy Ingestion Support to PyPI-Filter

### DIFF
--- a/kafka-filter-pypi/Dockerfile
+++ b/kafka-filter-pypi/Dockerfile
@@ -27,9 +27,10 @@ FROM debian:stable
 # install python3
 RUN apt -yqq update && apt install -yqq\
                         python3\
-                        python3-pip
+                        python3-pip\
+                        libpq-dev
 
-RUN pip3 install kafka-python python-dateutil
+RUN pip3 install kafka-python python-dateutil psycopg2
 
 # create dirs
 RUN mkdir /filter

--- a/kafka-filter-pypi/README.md
+++ b/kafka-filter-pypi/README.md
@@ -2,7 +2,7 @@ Kafka Filter for PyPI
 =====================
 
 Consumes PyPI packaging information in the
-[Warehouse](https://warehouse.readthedocs.io/) format from a kafka topic
+[Warehouse](https://warehouse.readthedocs.io/) format from multiple kafka topics
 and produces unique package-version tuples into another kafka topic.
 
 Usage
@@ -11,14 +11,14 @@ Usage
 ```
 >>> docker build -t pypi-filter .
 >>> docker run net=host -it pypi-filter\
-        <input_topic> <out_topic> <comma_separated_servers>\
+        <input_topics> <out_topic> <comma_separated_servers>\
         <consumer_group> <sleep_timeout> [--check-old]
 ```
 
 The list of parameters are:
 
-- `<input_topic>`: The kafka topic from which PyPI packaging information will
-  be consumed.
+- `<input_topics>`: A list of kafka topics from which PyPI packaging information will
+  be consumed, separated by a vertical bar. 
 - `<out_topic>`: The kafka topic where the unique package-version tuples will
   be stored.
 - `<comma_separated_servers>`: Thes list of kafka servers in use, separated by

--- a/kafka-filter-pypi/entrypoint.py
+++ b/kafka-filter-pypi/entrypoint.py
@@ -47,19 +47,19 @@ class PyPIFilter:
         if self.check_old:
             self._fill_old()
 
-    def _connect(self,  host_address, database_name, database_user):
+    def _connect(self, host_address, database_name, database_user):
         try:
             conn = psycopg2.connect(
-            host=host_address,
-            dbname=database_name,
-            user=database_user)
+                host=host_address,
+                dbname=database_name,
+                user=database_user)
             return conn
         except psycopg2.Error as e:
             print(e)
             sys.exit(0)
     
     def _exists_in_database(self, entry):
-        query = ''' SELECT *
+        query = '''SELECT *
                 FROM PACKAGES
                 INNER JOIN PACKAGE_VERSIONS ON PACKAGES.id = PACKAGE_VERSIONS.id
                 WHERE PACKAGES.package_name = %s AND PACKAGE_VERSIONS.version = %s'''

--- a/kafka-filter-pypi/entrypoint.py
+++ b/kafka-filter-pypi/entrypoint.py
@@ -61,8 +61,8 @@ class PyPIFilter:
     def _exists_in_database(self, entry):
         query = '''SELECT *
                 FROM PACKAGES
-                INNER JOIN PACKAGE_VERSIONS ON PACKAGES.id = PACKAGE_VERSIONS.id
-                WHERE PACKAGES.package_name = %s AND PACKAGE_VERSIONS.version = %s'''
+                INNER JOIN PACKAGE_VERSIONS ON PACKAGES.id=PACKAGE_VERSIONS.id
+                WHERE PACKAGES.package_name=%s AND PACKAGE_VERSIONS.version=%s'''
 
         self.cursor.execute(query,(entry["product"],entry["version"]))
         rows = self.cursor.fetchall()

--- a/kafka-filter-pypi/entrypoint.py
+++ b/kafka-filter-pypi/entrypoint.py
@@ -135,7 +135,7 @@ class PyPIFilter:
 
     def _extract(self, package):
         try:
-            is_ingested = True if package["ingested"] else False
+            is_ingested = True if "ingested" in package else False
             pkg_name = package["project"]["info"]["name"]
             requires_dist = package["project"]["info"]["requires_dist"]
             releases = package["project"]["releases"]
@@ -147,9 +147,9 @@ class PyPIFilter:
         requires_dist = self._parse_requires(requires_dist)
         for release in releases:
             if is_ingested:
+                version = release
                 if not releases.get(version, None):
                     continue
-                version = release
                 release_list = releases[version]
             else:
                 if not release.get("version", None) or\

--- a/kafka-filter-pypi/entrypoint.py
+++ b/kafka-filter-pypi/entrypoint.py
@@ -55,8 +55,8 @@ class PyPIFilter:
                 user=database_user)
             return conn
         except psycopg2.Error as e:
-            print(e)
-            sys.exit(0)
+            print("Could not connect to the PostgreSQL Database:", e)
+            sys.exit(1)
     
     def _exists_in_database(self, entry):
         query = '''SELECT *


### PR DESCRIPTION
## Description
This PR aims to extend the PyPI filter in order to support lazy ingestion:
* More specifically, we introduced an extra deduplication mechanism where we process a PyPI coordinate only if its does not exist in the Metadata Database.
* Additionally, we enabled our tool to process the format of the kafka records consumed from the ingestion topic produced by the Rest-API Plugin.
* Lastly, we enabled our Kafka consumer to subscribe to multiple Kafka topics (one produced by scrapping and one by lazy ingestion).
## Motivation 
In order to implement a lazy ingestion mechanism in the Python pipeline on monster, we need to be able to feed the pipeline with the ingestion records from the rest-api and also implement a deduplication mechanism to avoid redundant processes.
## Τest
Tested the tool on [docker compose](https://github.com/fasten-project/fasten-docker-deployment/tree/pypi-lazy-ingestion) and it had the expected behaviour when fed with either ingestion or release records.