### PR TITLE
Make PyCG-Producer Portable across Operating Systems

### DIFF
--- a/cg-producer/pycg_producer/producer.py
+++ b/cg-producer/pycg_producer/producer.py
@@ -252,7 +252,7 @@ class CallGraphGenerator:
         return self.out_file
 
     def _get_python_files(self, package):
-        return [x.resolve().as_posix().strip() for x in package.glob("**/*.py")]
+        return [x.as_posix().strip() for x in package.glob("**/*.py")]
 
     def _get_lines_of_code(self, files_list):
         res = 0

--- a/cg-producer/pycg_producer/producer.py
+++ b/cg-producer/pycg_producer/producer.py
@@ -238,9 +238,8 @@ class CallGraphGenerator:
             '--output', self.out_file.as_posix()
         ] + files_list
 
-        time_started = datetime.datetime.now().timestamp()
         result = self._execute_with_benchmark(cmd)
-        time_finished = datetime.datetime.now().timestamp()
+
         if result["process"]["stderr_data"]:
             self._format_error('generation', result["process"]["stderr_data"].strip())
             raise CallGraphGeneratorError()
@@ -248,7 +247,7 @@ class CallGraphGenerator:
         if not self.out_file.exists():
             self._format_error('generation', result["process"]["stderr_data"].strip())
             raise CallGraphGeneratorError()
-        self.elapsed = format(time_finished-time_started,".2f")
+        self.elapsed = result["process"]["execution_time"]
         self.max_rss = round(result["memory"]["max"]/1000)
         return self.out_file
 

--- a/cg-producer/setup.py
+++ b/cg-producer/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from distutils.core import setup
+from setuptools import setup
 
 def get_long_desc():
     with open("PyPI-README.md", "r") as readme:
@@ -9,7 +9,7 @@ def get_long_desc():
     return desc
 
 setup(name='pycg-producer',
-      version='0.0.6',
+      version='0.0.7',
       license='Apache Software License',
       long_description=get_long_desc(),
       long_description_content_type='text/markdown',
@@ -19,5 +19,5 @@ setup(name='pycg-producer',
       url='https://github.com/fasten-project/pypi-tools/tree/main/cg-producer',
       packages=['pycg_producer'],
       include_package_data=True,
-      install_requires=['pycg>=0.0.6'],
+      install_requires=['pycg>=0.0.6', 'cmdbench'],
      )


### PR DESCRIPTION
# Description
This PR aims to close #7 by replacing the subprocess command used for building the call graph and for measuring the time and memory consumpton with the benchmark command of the cmdbench library. On this way, we make pycg-producer portable across platforms regardless of the operating system.