### PR TITLE
Changed lazy ingestion not to process all versions.

### DIFF
--- a/kafka-filter-pypi/entrypoint.py
+++ b/kafka-filter-pypi/entrypoint.py
@@ -73,7 +73,6 @@ class PyPIFilter:
     def consume(self):
         self._init_kafka()
 
-        # todo: separate message consuming logic for lazy ingestion and batch crawl here
         for message in self.consumer:
             package = message.value
             print("{}: Consuming {}".format(


### PR DESCRIPTION
When triggering lazy ingestion of package version, change the [kafka-filter-pypi](https://github.com/fasten-project/pypi-tools/tree/main/kafka-filter-pypi) behaviour to not process all the versions.